### PR TITLE
Validate medicines pagination parameters

### DIFF
--- a/BE-farm/pig_farm/core/apis.py
+++ b/BE-farm/pig_farm/core/apis.py
@@ -4,10 +4,27 @@ from django.db import connection
 
 @api_view(["GET"])
 def medicines(request):
-    page = int(request.GET.get("page", 1))
-    size = int(request.GET.get("page_size", 20))
-    offset = (page-1)*size
+    default_page = 1
+    default_size = 20
+
+    try:
+        page = int(request.GET.get("page", default_page))
+    except (TypeError, ValueError):
+        page = default_page
+
+    try:
+        size = int(request.GET.get("page_size", default_size))
+    except (TypeError, ValueError):
+        size = default_size
+
+    if page < 1 or size < 1:
+        return Response({"detail": "page and page_size must be positive integers."}, status=400)
+
+    offset = (page - 1) * size
     with connection.cursor() as cur:
-        cur.execute("SELECT * FROM v_medicine_public ORDER BY published_at DESC, id DESC LIMIT %s OFFSET %s", [size, offset])
+        cur.execute(
+            "SELECT * FROM v_medicine_public ORDER BY published_at DESC, id DESC LIMIT %s OFFSET %s",
+            [size, offset],
+        )
         rows = [dict(zip([c.name for c in cur.description], r)) for r in cur.fetchall()]
     return Response({"page": page, "items": rows})

--- a/BE-farm/pig_farm/core/tests.py
+++ b/BE-farm/pig_farm/core/tests.py
@@ -1,3 +1,50 @@
-from django.test import TestCase
+from unittest.mock import MagicMock, patch
 
-# Create your tests here.
+from django.test import TestCase
+from rest_framework.test import APIRequestFactory
+
+from .apis import medicines
+
+
+class MedicinesApiTests(TestCase):
+    def setUp(self):
+        self.factory = APIRequestFactory()
+
+    def _mock_cursor(self):
+        mock_cursor = MagicMock()
+        mock_cursor.__enter__.return_value = mock_cursor
+        mock_cursor.__exit__.return_value = False
+        mock_cursor.description = []
+        mock_cursor.fetchall.return_value = []
+        return mock_cursor
+
+    @patch("pig_farm.core.apis.connection")
+    def test_page_less_than_one_returns_400(self, mock_connection):
+        request = self.factory.get("/medicines/", {"page": "0"})
+        response = medicines(request)
+
+        self.assertEqual(response.status_code, 400)
+        mock_connection.cursor.assert_not_called()
+
+    @patch("pig_farm.core.apis.connection")
+    def test_page_size_less_than_one_returns_400(self, mock_connection):
+        request = self.factory.get("/medicines/", {"page_size": "0"})
+        response = medicines(request)
+
+        self.assertEqual(response.status_code, 400)
+        mock_connection.cursor.assert_not_called()
+
+    @patch("pig_farm.core.apis.connection")
+    def test_non_integer_values_default_to_safe_numbers(self, mock_connection):
+        mock_cursor = self._mock_cursor()
+        mock_connection.cursor.return_value = mock_cursor
+
+        request = self.factory.get("/medicines/", {"page": "abc", "page_size": "xyz"})
+        response = medicines(request)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["page"], 1)
+        mock_cursor.execute.assert_called_once_with(
+            "SELECT * FROM v_medicine_public ORDER BY published_at DESC, id DESC LIMIT %s OFFSET %s",
+            [20, 0],
+        )


### PR DESCRIPTION
## Summary
- add defensive casting and validation for pagination parameters in the medicines API
- short-circuit with a 400 response for non-positive pagination values
- cover invalid pagination inputs with API tests to ensure safe defaults and error responses

## Testing
- python manage.py test core.tests.MedicinesApiTests *(fails: ModuleNotFoundError: No module named 'wagtail_modeladmin')*

------
https://chatgpt.com/codex/tasks/task_e_68cb1ff8972c832899ec898347a30338